### PR TITLE
configure log4j to prevent memory leak

### DIFF
--- a/src/main/resources/log4j.properties
+++ b/src/main/resources/log4j.properties
@@ -1,0 +1,4 @@
+log4j.rootLogger=INFO, ROOT
+
+log4j.appender.ROOT=org.apache.log4j.varia.NullAppender
+log4j.appender.ROOT.layout=org.apache.log4j.PatternLayout


### PR DESCRIPTION
log4j causes memory leak without config.

before
![https://gyazo.com/e37675132d757f77a4063ec794abf4e8](https://gyazo.com/e37675132d757f77a4063ec794abf4e8/raw)


after
![https://gyazo.com/198a32a34c9c21cc581b0256a21036ef](https://gyazo.com/198a32a34c9c21cc581b0256a21036ef/raw)

related URL

[https://forums.aws.amazon.com/thread.jspa?threadID=264257](https://forums.aws.amazon.com/thread.jspa?threadID=264257)