### PR TITLE
Add database schema when a schema is not explicitly specified in a query

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Athena input plugin for Embulk loads records from Athena(AWS).
 
 ## Configuration
 
-* **driver_path**: path to the jar file of the Athena JDBC driver. If not set, the bundled JDBC driver(AthenaJDBC41-1.1.0.jar) will be used. (string)
+* **driver_path**: path to the jar file of the Athena JDBC driver. If not set, the bundled JDBC driver(AthenaJDBC41.jar) will be used. (string)
 * **database**: database name (string, required)
 * **athena_url**: Athena url (string, required)
 * **s3_staging_dir**: The S3 location to which your query output is written, for example s3://query-results-bucket/folder/. (string, required)

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ dependencies {
     compile  "org.embulk:embulk-core:0.8.39"
     provided "org.embulk:embulk-core:0.8.39"
     // TODO: maven...
-    compile files ('build/AthenaJDBC41-1.1.0.jar')
+    compile files ('build/AthenaJDBC41.jar')
     compile group: 'com.amazonaws', name: 'aws-java-sdk', version: '1.11.301'
     // compile group: 'com.amazonaws', name: 'aws-java-sdk-athena', version: '1.11.301'
     compile 'org.embulk.input.jdbc:embulk-input-jdbc:0.9.1'
@@ -33,7 +33,7 @@ dependencies {
 }
 
 task downloadFile(type: Download) {
-    src 'https://s3.amazonaws.com/athena-downloads/drivers/AthenaJDBC41-1.1.0.jar'
+    src 'https://s3.amazonaws.com/athena-downloads/drivers/JDBC/SimbaAthenaJDBC-2.0.23.1000/AthenaJDBC41.jar'
     dest buildDir
     onlyIfModified true
 }
@@ -41,7 +41,7 @@ task downloadFile(type: Download) {
 task classpath(type: Copy, dependsOn: ["downloadFile", "jar"]) {
     doFirst { file("classpath").deleteDir() }
     from (configurations.runtime - configurations.provided + files(jar.archivePath))
-    from ("build/AthenaJDBC41-1.1.0.jar'")
+    from ("build/AthenaJDBC41.jar")
     into "classpath"
 }
 clean { delete "classpath" }

--- a/src/main/java/org/embulk/input/athena/AthenaInputPlugin.java
+++ b/src/main/java/org/embulk/input/athena/AthenaInputPlugin.java
@@ -259,7 +259,7 @@ public class AthenaInputPlugin implements InputPlugin
 
     protected Connection getAthenaConnection(PluginTask task) throws ClassNotFoundException, SQLException
     {
-        loadDriver("com.amazonaws.athena.jdbc.AthenaDriver", task.getDriverPath());
+        loadDriver("com.simba.athena.jdbc.Driver", task.getDriverPath());
         Properties properties = new Properties();
         properties.put("s3_staging_dir", task.getS3StagingDir());
         properties.put("user", task.getAccessKey());

--- a/src/main/java/org/embulk/input/athena/AthenaInputPlugin.java
+++ b/src/main/java/org/embulk/input/athena/AthenaInputPlugin.java
@@ -264,6 +264,7 @@ public class AthenaInputPlugin implements InputPlugin
         properties.put("s3_staging_dir", task.getS3StagingDir());
         properties.put("user", task.getAccessKey());
         properties.put("password", task.getSecretKey());
+        properties.put("schema", task.getDatabase());
         properties.putAll(task.getOptions());
 
         return DriverManager.getConnection(task.getAthenaUrl(), properties);

--- a/src/main/resources/log4j.properties
+++ b/src/main/resources/log4j.properties
@@ -1,4 +1,4 @@
 log4j.rootLogger=INFO, ROOT
 
-log4j.appender.ROOT=org.apache.log4j.varia.NullAppender
-log4j.appender.ROOT.layout=org.apache.log4j.PatternLayout
+log4j.appender.ROOT=com.simba.athena.shaded.apache.log4j.varia.NullAppender
+log4j.appender.ROOT.layout=com.simba.athena.shaded.apache.log4j.PatternLayout


### PR DESCRIPTION
To specify a database schema, set the value of schema.
The following information is for your reference.
https://s3.amazonaws.com/athena-downloads/drivers/JDBC/SimbaAthenaJDBC-2.0.23.1000/docs/Simba+Athena+JDBC+Connector+Install+and+Configuration+Guide.pdf

And, To use schema, It need to update the JDBC Driver to 2.x.x.